### PR TITLE
feat: first draft of new Agents module

### DIFF
--- a/backend/Project.toml
+++ b/backend/Project.toml
@@ -1,0 +1,14 @@
+name = "JuliaOSBackend"
+uuid = "12345678-1234-5678-1234-567812345678"
+authors = ["JuliaOS Contributors <contributors@juliaos.org>"]
+version = "0.1.0"
+
+[deps]
+
+[sources]
+
+[compat]
+
+[extras]
+
+[targets]

--- a/backend/src/JuliaOSBackend.jl
+++ b/backend/src/JuliaOSBackend.jl
@@ -1,0 +1,7 @@
+module JuliaOSBackend
+
+include("agents/Agents.jl")
+
+using .Agents
+
+end

--- a/backend/src/agents/Agents.jl
+++ b/backend/src/agents/Agents.jl
@@ -1,0 +1,14 @@
+module Agents
+
+include("CommonTypes.jl")
+include("tools/Tools.jl")
+include("strategies/Strategies.jl")
+
+using .CommonTypes, .Tools, .Strategies
+
+include("utils.jl")
+include("agent_management.jl")
+
+export create_agent
+
+end

--- a/backend/src/agents/CommonTypes.jl
+++ b/backend/src/agents/CommonTypes.jl
@@ -1,0 +1,93 @@
+module CommonTypes
+
+# Tools:
+
+abstract type ToolConfig end
+
+struct ToolMetadata
+    name::String
+    description::String
+end
+
+struct ToolSpecification
+    execute::Function
+    config_type::DataType
+    metadata::ToolMetadata
+end
+
+struct InstantiatedTool
+    execute::Function
+    config::ToolConfig
+    metadata::ToolMetadata
+end
+
+# Agent internals:
+
+@enum AgentState CREATED_STATE RUNNING_STATE PAUSED_STATE STOPPED_STATE
+
+struct AgentContext
+    tools::Vector{InstantiatedTool}
+    logs::Vector{String}
+end
+
+# Triggers:
+
+@enum TriggerType PERIODIC_TRIGGER WEBHOOK_TRIGGER
+
+abstract type TriggerParams end
+
+struct TriggerConfig
+    type::TriggerType
+    params::TriggerParams
+end
+
+struct PeriodicTriggerParams <: TriggerParams
+    interval::Int  # Interval in seconds
+end
+
+struct WebhookTriggerParams <: TriggerParams
+end
+
+# Strategies:
+
+abstract type StrategyConfig end
+
+struct StrategySpecification
+    run::Function
+    config_type::DataType
+end
+
+struct InstantiatedStrategy
+    run::Function
+    config::StrategyConfig
+end
+
+# Blueprints:
+
+struct ToolBlueprint
+    name::String
+    config_data::Dict{String, Any}
+end
+
+struct StrategyBlueprint
+    name::String
+    config_data::Dict{String, Any}
+end
+
+struct AgentBlueprint
+    tools::Vector{ToolBlueprint}
+    strategy::StrategyBlueprint
+    trigger::TriggerConfig
+end
+
+# Agent proper:
+
+mutable struct Agent
+    id::String
+    context::AgentContext
+    strategy::InstantiatedStrategy
+    trigger::TriggerConfig
+    state::AgentState
+end
+
+end

--- a/backend/src/agents/agent_management.jl
+++ b/backend/src/agents/agent_management.jl
@@ -1,0 +1,78 @@
+using .CommonTypes: Agent, AgentBlueprint, AgentContext, AgentState, InstantiatedTool, InstantiatedStrategy, CommonTypes
+
+const AGENTS = Dict{String, Agent}()
+
+function create_agent(
+    id::String,
+    blueprint::AgentBlueprint,
+)::Agent
+    # Check if the agent with the given ID already exists
+    if haskey(AGENTS, id)
+        error("Agent with ID '$id' already exists.")
+    end
+
+    # Instantiate tools from the blueprint
+    tools = Vector{InstantiatedTool}()
+    for tool_blueprint in blueprint.tools
+        tool = instantiate_tool(tool_blueprint)
+        push!(tools, tool)
+    end
+
+    # Create the agent context
+    context = AgentContext(
+        tools,
+        Vector{String}()
+    )
+
+    # Create the instantiated strategy
+    strategy = instantiate_strategy(blueprint.strategy)
+
+    # Create the agent
+    agent = Agent(
+        id,
+        context,
+        strategy,
+        blueprint.trigger,
+        CommonTypes.CREATED_STATE
+    )
+
+    AGENTS[id] = agent
+
+    return agent
+end
+
+function delete_agent(
+    id::String,
+)::Nothing
+    # Check if the agent with the given ID exists
+    if !haskey(AGENTS, id)
+        error("Agent with ID '$id' does not exist.")
+    end
+
+    # Remove the agent from the registry
+    delete!(AGENTS, id)
+
+    return nothing
+end
+
+function set_agent_state(
+    agent::Agent,
+    new_state::AgentState,
+)
+    # TODO: actually make sure the transition is valid and realized fully
+    agent.state = new_state
+
+    return nothing
+end
+
+function run(
+    agent::Agent,
+    input::Any=nothing,
+)
+    if agent.state != CommonTypes.RUNNING_STATE
+        error("Agent with ID '$(agent.id)' is not in RUNNING state.")
+    end
+
+    @info "Executing strategy of agent $(agent.id)"
+    return agent.strategy.run(agent.strategy.config, agent.context, input)
+end

--- a/backend/src/agents/strategies/Strategies.jl
+++ b/backend/src/agents/strategies/Strategies.jl
@@ -1,0 +1,22 @@
+module Strategies
+
+export STRATEGY_REGISTRY
+
+include("strategy_example_adder.jl")
+
+using ..CommonTypes: StrategySpecification
+
+const STRATEGY_REGISTRY = Dict{String, StrategySpecification}()
+
+function register_strategy(strategy_name::String, strategy_spec::StrategySpecification)
+    if haskey(STRATEGY_REGISTRY, strategy_name)
+        error("Strategy with name '$strategy_name' is already registered.")
+    end
+    STRATEGY_REGISTRY[strategy_name] = strategy_spec
+end
+
+# All strategies to be used by agents must be registered here:
+
+register_strategy("adder", STRATEGY_EXAMPLE_ADDER_SPECIFICATION)
+
+end

--- a/backend/src/agents/strategies/strategy_example_adder.jl
+++ b/backend/src/agents/strategies/strategy_example_adder.jl
@@ -1,0 +1,34 @@
+# Example implementation of a strategy. The STRATEGY_EXAMPLE_ADDER_SPECIFICATION struct encapsulates the implementation and is the part added to the registry in Strategy.jl.
+
+using ..CommonTypes: StrategyConfig, AgentContext, StrategySpecification
+
+Base.@kwdef struct StrategyExampleAdderConfig <: StrategyConfig
+    times_to_add::Int
+end
+
+function strategy_example_adder(cfg::StrategyExampleAdderConfig, ctx::AgentContext, input::Any) # TODO: input needs to be more generic
+    if !isa(input, Int)
+        push!(ctx.logs, "ERROR: Input must be an integer.")
+        return
+    end
+
+    value = input
+
+    adder_tool_index = findfirst(tool -> tool.metadata.name == "adder", ctx.tools)
+    if adder_tool_index === nothing
+        push!(ctx.logs, "ERROR: Adder tool not found in context tools.")
+        return
+    end
+    adder_tool = ctx.tools[adder_tool_index]
+
+    for _ in 1:cfg.times_to_add
+        value = adder_tool.execute(adder_tool.config, value)
+        push!(ctx.logs, "Adder tool result: $value")
+    end
+    return ctx
+end
+
+const STRATEGY_EXAMPLE_ADDER_SPECIFICATION = StrategySpecification(
+    strategy_example_adder,
+    StrategyExampleAdderConfig
+)

--- a/backend/src/agents/tools/Tools.jl
+++ b/backend/src/agents/tools/Tools.jl
@@ -1,0 +1,22 @@
+module Tools
+
+export TOOL_REGISTRY
+
+include("tool_example_adder.jl")
+
+using ..CommonTypes: ToolSpecification
+
+const TOOL_REGISTRY = Dict{String, ToolSpecification}()
+
+function register_tool(tool_name::String, tool_spec::ToolSpecification)
+    if haskey(TOOL_REGISTRY, tool_name)
+        error("Tool with name '$tool_name' is already registered.")
+    end
+    TOOL_REGISTRY[tool_name] = tool_spec
+end
+
+# All tools to be used by agents must be registered here:
+
+register_tool("adder", TOOL_EXAMPLE_ADDER_SPECIFICATION)
+
+end

--- a/backend/src/agents/tools/tool_example_adder.jl
+++ b/backend/src/agents/tools/tool_example_adder.jl
@@ -1,0 +1,22 @@
+# Example implementation of a tool. The TOOL_EXAMPLE_ADDER_SPECIFICATION struct encapsulates the implementation and is the part added to the registry in Tools.jl.
+
+using ..CommonTypes: ToolSpecification, ToolMetadata, ToolConfig
+
+Base.@kwdef struct ToolExampleAdderConfig <: ToolConfig
+    add_value::Integer
+end
+
+function tool_example_adder(config::ToolExampleAdderConfig, input::Integer)::Integer
+    return input + config.add_value
+end
+
+const TOOL_EXAMPLE_ADDER_METADATA::ToolMetadata = ToolMetadata(
+    "adder",
+    "Adds a specified value to the input integer."
+)
+
+const TOOL_EXAMPLE_ADDER_SPECIFICATION::ToolSpecification = ToolSpecification(
+    tool_example_adder,
+    ToolExampleAdderConfig,
+    TOOL_EXAMPLE_ADDER_METADATA
+)

--- a/backend/src/agents/utils.jl
+++ b/backend/src/agents/utils.jl
@@ -1,0 +1,45 @@
+using .CommonTypes: InstantiatedTool, InstantiatedStrategy, StrategyBlueprint, ToolBlueprint
+
+function deserialize_object(object_type::DataType, data::Dict{String, Any})
+    expected_fields = fieldnames(object_type)
+    provided_fields = Symbol.(keys(data))
+
+    unexpected_fields = setdiff(provided_fields, expected_fields)
+    missing_fields = setdiff(expected_fields, provided_fields)
+
+    if !isempty(missing_fields)
+        @warn "Missing fields in data: $(missing_fields)"
+    end
+    if !isempty(unexpected_fields)
+        @warn "Unexpected fields in data: $(unexpected_fields)"
+    end
+
+    #@info "Deserializing object of type $(object_type) with data: $(data)"
+    symbolic_data = Dict(Symbol(k) => v for (k, v) in data)
+    return object_type(; symbolic_data...)
+end
+
+function instantiate_tool(blueprint::ToolBlueprint)::InstantiatedTool
+    if !haskey(Tools.TOOL_REGISTRY, blueprint.name)
+        error("Tool '$(blueprint.name)' is not registered.")
+    end
+
+    tool_spec = Tools.TOOL_REGISTRY[blueprint.name]
+
+    tool_config = deserialize_object(tool_spec.config_type, blueprint.config_data)
+
+    return InstantiatedTool(tool_spec.execute, tool_config, tool_spec.metadata)
+end
+
+
+function instantiate_strategy(blueprint::StrategyBlueprint)::InstantiatedStrategy
+    if !haskey(Strategies.STRATEGY_REGISTRY, blueprint.name)
+        error("Strategy '$(blueprint.name)' is not registered.")
+    end
+
+    strategy_spec = Strategies.STRATEGY_REGISTRY[blueprint.name]
+
+    strategy_config = deserialize_object(strategy_spec.config_type, blueprint.config_data)
+
+    return InstantiatedStrategy(strategy_spec.run, strategy_config)
+end

--- a/backend/temp_test.jl
+++ b/backend/temp_test.jl
@@ -1,0 +1,63 @@
+using Pkg
+Pkg.activate(".")
+
+using JuliaOSBackend.Agents
+using JuliaOSBackend.Agents.CommonTypes: AgentBlueprint, ToolBlueprint, StrategyBlueprint, TriggerConfig, WebhookTriggerParams
+
+function main()
+    @info "Supported tools:"
+    for (name, spec) in Agents.Tools.TOOL_REGISTRY
+        @info " - $name: $spec"
+    end
+    @info "Supported strategies:"
+    for (name, spec) in Agents.Strategies.STRATEGY_REGISTRY
+        @info " - $name: $spec"
+    end
+
+    example_blueprint = AgentBlueprint(
+        [
+            ToolBlueprint("adder", Dict("add_value" => 3))
+        ],
+        StrategyBlueprint(
+            "adder",
+            Dict("times_to_add" => 5)
+        ),
+        TriggerConfig(
+            Agents.CommonTypes.WEBHOOK_TRIGGER,
+            WebhookTriggerParams()
+        )
+    )
+
+    example_agent = Agents.create_agent("example_agent", example_blueprint)
+    @info "Created agent: $example_agent"
+
+    @info "Exising agents:"
+    for (name, agent) in Agents.AGENTS
+        @info " - $name: $agent"
+    end
+
+    Agents.set_agent_state(example_agent, Agents.CommonTypes.RUNNING_STATE)
+    
+    Agents.run(example_agent)
+
+    @info "Agent logs:"
+    for log in example_agent.context.logs
+        @info " - $log"
+    end
+
+    Agents.run(example_agent, 7)
+
+    @info "Agent logs:"
+    for log in example_agent.context.logs
+        @info " - $log"
+    end
+
+    @info "Exising agents:"
+    for (name, agent) in Agents.AGENTS
+        @info " - $name: $agent"
+    end
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    main()
+end


### PR DESCRIPTION
Adds a new `backend` directory with an `Agents` module according to the discussed design. The idea is to use this as the new `julia` directory and slowly expand it / move useful code there. Many details are open to change / discussion, the priority is to provide the core structure that we will use.

To execute the included test script, navigate to the `backend` directory and run
```
julia --project=. temp_test.jl
```

New tools can be added to the `Tools` submodule, see `tool_example_adder.jl` for an example. Analogously for strategies, the `Strategies` submodule and `strategy_example_adder.jl`.

Left to do until MVP:
- [x] Core agent infrastructure
- [ ] Trigger and agent state integration
- [ ] Endpoint integration