### PR TITLE
feat: add OpenAI streaming output support

### DIFF
--- a/julia/.env.example
+++ b/julia/.env.example
@@ -2,6 +2,8 @@
 
 # API Keys
 OPENAI_API_KEY=your-openai-api-key
+OPENAI_BASE_URL=some-base-url
+OPENAI_MODEL=llama3-8b-8192
 ANTHROPIC_API_KEY=your-anthropic-api-key
 COINGECKO_API_KEY=your_coingecko_key
 COINMARKETCAP_API_KEY=your_coinmarketcap_key

--- a/julia/run_agent.jl
+++ b/julia/run_agent.jl
@@ -86,12 +86,21 @@ function run_plan_execute_example()
     # Here we're using the existing ping and llm_chat abilities, but you could create more specialized ones
 
     # Create a new agent to use with PlanAndExecute
+    # Configure LLM parameters
+    llm_config = Dict{String, Any}(
+        "api_key" => ENV["OPENAI_API_KEY"],
+        "api_base" => ENV["OPENAI_BASE_URL"],
+        "model" => ENV["OPENAI_MODEL"],
+        "temperature" => 0.7,
+        "max_tokens" => 1024
+    )
+
     plan_agent_cfg = JuliaOS.JuliaOSFramework.AgentCore.AgentConfig(
         "PlanExecuteAgent",
         JuliaOS.JuliaOSFramework.AgentCore.CUSTOM;
         abilities=["ping", "llm_chat"],
         parameters=Dict{String, Any}("demo" => true),
-        llm_config=Dict{String, Any}(),
+        llm_config=llm_config,  # Add LLM config
         memory_config=Dict{String, Any}(),
         queue_config=Dict{String, Any}(),
     )
@@ -115,10 +124,11 @@ function run_plan_execute_example()
 
     # Create a PlanAndExecute agent
     @info "Creating PlanAndExecute agent"
+    
     plan_execute_agent = JuliaOS.JuliaOSFramework.PlanAndExecute.create_plan_execute_agent(
         plan_agent.id,
         tools,
-        Dict{String, Any}()  # LLM config (using defaults)
+        llm_config  # Use the same LLM config
     )
 
     # Define a task for the agent to solve
@@ -140,7 +150,75 @@ function run_plan_execute_example()
     @info "PlanExecute Agent $(plan_agent.id) stopped successfully"
 end
 
-if abspath(PROGRAM_FILE) == @__FILE__
-    # main()
-    run_plan_execute_example()
+# Create a streaming chat agent
+function run_streaming_chat_example()
+    # Configure LLM parameters
+    llm_config = Dict{String, Any}(
+        "provider" => "openai",
+        "api_key" => ENV["OPENAI_API_KEY"],
+        "api_base" => ENV["OPENAI_BASE_URL"],
+        "model" => ENV["OPENAI_MODEL"],
+        "temperature" => 0.7,
+        "max_tokens" => 8092,
+        "stream" => false  # Enable streaming output
+    )
+
+    # Create agent config
+    chat_agent_cfg = JuliaOS.JuliaOSFramework.AgentCore.AgentConfig(
+        "StreamingChatAgent",
+        JuliaOS.JuliaOSFramework.AgentCore.CUSTOM;
+        abilities=["llm_chat"],
+        parameters=Dict{String, Any}("demo" => true),
+        llm_config=llm_config,  # Add LLM config
+        memory_config=Dict{String, Any}(),
+        queue_config=Dict{String, Any}(),
+    )
+
+    # Create agent
+    chat_agent = JuliaOS.JuliaOSFramework.Agents.createAgent(chat_agent_cfg)
+    @info "Streaming Chat Agent $(chat_agent.id) created successfully"
+
+    # Start agent
+    JuliaOS.JuliaOSFramework.Agents.startAgent(chat_agent.id)
+    @info "Streaming Chat Agent $(chat_agent.id) started successfully"
+
+    # Execute chat task
+    prompt = "Hello! Can you write a 1000-word essay for me? The topic is modernization!"
+    @info "Start chat, input: $prompt"
+    
+    # Use streaming output
+    result = JuliaOS.JuliaOSFramework.Agents.executeAgentTask(
+        chat_agent.id, 
+        Dict{String, Any}(
+            "ability" => "llm_chat",
+            "prompt" => prompt,
+        )
+    )
+    
+    # Handle streaming response
+    @info "Start receiving streaming response..."
+    if isa(result, Dict) && haskey(result, "answer")
+        ch = result["answer"]
+        for content in ch
+            print(content)
+            flush(stdout)
+        end
+        println()
+    else
+        @info "Received normal response"
+        @show result
+    end
+    
+    @info "Chat completed"
+
+    # Stop agent
+    JuliaOS.JuliaOSFramework.Agents.stopAgent(chat_agent.id)
+    @info "Streaming Chat Agent $(chat_agent.id) stopped successfully"
 end
+
+# if abspath(PROGRAM_FILE) == @__FILE__
+#     # main()
+#     # run_plan_execute_example()
+#     run_streaming_chat_example()
+# end
+run_streaming_chat_example()


### PR DESCRIPTION

Key Updates:
1. Added streaming output support
   - Added chat_stream interface for handling streaming responses
   - Implemented OpenAI streaming output logic
   - Support returning streaming content via Channel

2. Enhanced LLM configuration
   - Added OPENAI_BASE_URL and OPENAI_MODEL to .env.example
   - Improved LLM component creation logic with more configuration options

3. New example code
   - Added run_streaming_chat_example function to demonstrate streaming output
   - Optimized LLM configuration in run_plan_execute_example

4. Improved logging
   - Added logging at key points
   - Enhanced error handling and debug information

Technical Details:
- Implemented streaming data transfer using Channel
- Support for SSE (Server-Sent Events) response format
- Maintained compatibility with existing non-streaming interfaces



![image](https://github.com/user-attachments/assets/f8864fe5-10c1-4fe3-b3d4-acd89099cf1a)
