### PR TITLE
fix: server response status codes

### DIFF
--- a/backend/src/api/JuliaOSV1Server.jl
+++ b/backend/src/api/JuliaOSV1Server.jl
@@ -15,7 +15,7 @@ function ping(::HTTP.Request)
     return HTTP.Response(200, "")
 end
 
-function create_agent(req::HTTP.Request, create_agent_request::CreateAgentRequest;)::AgentSummary
+function create_agent(req::HTTP.Request, create_agent_request::CreateAgentRequest;)::HTTP.Response
     @info "Triggered endpoint: POST /agents"
 
     id = create_agent_request.id
@@ -39,7 +39,8 @@ function create_agent(req::HTTP.Request, create_agent_request::CreateAgentReques
 
     agent = Agents.create_agent(id, name, description, internal_blueprint)
     @info "Created agent: $(agent.id) with state: $(agent.state)"
-    return AgentSummary(agent.id, agent.name, agent.description, Agents.agent_state_to_string(agent.state), Agents.trigger_type_to_string(agent.trigger.type))
+    agent_summary = AgentSummary(agent.id, agent.name, agent.description, Agents.agent_state_to_string(agent.state), Agents.trigger_type_to_string(agent.trigger.type))
+    return HTTP.Response(201, agent_summary)
 end
 
 function delete_agent(req::HTTP.Request, agent_id::String;)::Nothing

--- a/backend/src/api/JuliaOSV1Server.jl
+++ b/backend/src/api/JuliaOSV1Server.jl
@@ -43,29 +43,32 @@ function create_agent(req::HTTP.Request, create_agent_request::CreateAgentReques
     return HTTP.Response(201, agent_summary)
 end
 
-function delete_agent(req::HTTP.Request, agent_id::String;)::Nothing
+function delete_agent(req::HTTP.Request, agent_id::String;)::HTTP.Response
     @info "Triggered endpoint: DELETE /agents/$(agent_id)"
     Agents.delete_agent(agent_id)
     @info "Deleted agent $(agent_id)"
-    return nothing
+    return HTTP.Response(204)
 end
 
-function update_agent(req::HTTP.Request, agent_id::String, agent_update::AgentUpdate;)::AgentSummary
+function update_agent(req::HTTP.Request, agent_id::String, agent_update::AgentUpdate;)::HTTP.Response
     @info "Triggered endpoint: PUT /agents/$(agent_id)"
     agent = get(Agents.AGENTS, agent_id) do
         error("Agent $(agent_id) does not exist!")
+        return HTTP.Response(404, "Agent not found")
     end
     new_state = Agents.string_to_agent_state(agent_update.state)
     Agents.set_agent_state(agent, new_state)
-    return AgentSummary(agent.id, agent.name, agent.description, Agents.agent_state_to_string(agent.state), Agents.trigger_type_to_string(agent.trigger.type))
+    agent_summary = AgentSummary(agent.id, agent.name, agent.description, Agents.agent_state_to_string(agent.state), Agents.trigger_type_to_string(agent.trigger.type))
+    return HTTP.Response(200, agent_summary)
 end
 
-function get_agent(req::HTTP.Request, agent_id::String;)::AgentSummary
+function get_agent(req::HTTP.Request, agent_id::String;)::HTTP.Response
     @info "Triggered endpoint: GET /agents/$(agent_id)"
     agent = get(Agents.AGENTS, agent_id) do
         error("Agent $(agent_id) does not exist!")
     end
-    return AgentSummary(agent.id, agent.name, agent.description, Agents.agent_state_to_string(agent.state), Agents.trigger_type_to_string(agent.trigger.type))
+    agent_summary = AgentSummary(agent.id, agent.name, agent.description, Agents.agent_state_to_string(agent.state), Agents.trigger_type_to_string(agent.trigger.type))
+    return HTTP.Response(200, agent_summary)
 end
 
 function list_agents(req::HTTP.Request;)::Vector{AgentSummary}
@@ -77,10 +80,11 @@ function list_agents(req::HTTP.Request;)::Vector{AgentSummary}
     return agents
 end
 
-function process_agent_webhook(req::HTTP.Request, agent_id::String; request_body::Dict{String,Any}=Dict{String,Any}(),)::Nothing
+function process_agent_webhook(req::HTTP.Request, agent_id::String; request_body::Dict{String,Any}=Dict{String,Any}(),)::HTTP.Response
     @info "Triggered endpoint: POST /agents/$(agent_id)/webhook"
     agent = get(Agents.AGENTS, agent_id) do
         error("Agent $(agent_id) does not exist!")
+        return HTTP.Response(404, "Agent not found")
     end
     if agent.trigger.type == Agents.CommonTypes.WEBHOOK_TRIGGER
         @info "Triggering agent $(agent_id) by webhook"
@@ -91,13 +95,14 @@ function process_agent_webhook(req::HTTP.Request, agent_id::String; request_body
             Agents.run(agent)
         end
     end
-    return nothing
+    return HTTP.Response(200)
 end
 
-function get_agent_logs(req::HTTP.Request, agent_id::String;)::Dict{String, Any}
+function get_agent_logs(req::HTTP.Request, agent_id::String;)::Union{HTTP.Response, Dict{String, Any}}
     @info "Triggered endpoint: GET /agents/$(agent_id)/logs"
     agent = get(Agents.AGENTS, agent_id) do
         error("Agent $(agent_id) does not exist!")
+        return HTTP.Response(404, "Agent not found")
     end
     # TODO: implement pagination
     return Dict{String, Any}("logs" => agent.context.logs)

--- a/backend/src/api/JuliaOSV1Server.jl
+++ b/backend/src/api/JuliaOSV1Server.jl
@@ -20,12 +20,6 @@ function create_agent(req::HTTP.Request, create_agent_request::CreateAgentReques
     @info "Triggered endpoint: POST /agents"
     @validate_model create_agent_request
 
-    #validation = validate_model(create_agent_request)
-    #if validation !== nothing
-    #    @error "Validation failed for CreateAgentRequest: $(validation.body)"
-    #    return validation
-    #end
-
     id = create_agent_request.id
     name = create_agent_request.name
     description = create_agent_request.description

--- a/backend/src/api/JuliaOSV1Server.jl
+++ b/backend/src/api/JuliaOSV1Server.jl
@@ -4,6 +4,7 @@ using HTTP
 
 include("server/src/JuliaOSServer.jl")
 include("openapi_server_extensions.jl")
+include("validation.jl")
 
 using .JuliaOSServer
 using ..Agents: Agents, Triggers
@@ -17,6 +18,13 @@ end
 
 function create_agent(req::HTTP.Request, create_agent_request::CreateAgentRequest;)::HTTP.Response
     @info "Triggered endpoint: POST /agents"
+    @validate_model create_agent_request
+
+    #validation = validate_model(create_agent_request)
+    #if validation !== nothing
+    #    @error "Validation failed for CreateAgentRequest: $(validation.body)"
+    #    return validation
+    #end
 
     id = create_agent_request.id
     name = create_agent_request.name
@@ -52,6 +60,8 @@ end
 
 function update_agent(req::HTTP.Request, agent_id::String, agent_update::AgentUpdate;)::HTTP.Response
     @info "Triggered endpoint: PUT /agents/$(agent_id)"
+    @validate_model agent_update
+
     agent = get(Agents.AGENTS, agent_id) do
         error("Agent $(agent_id) does not exist!")
         return HTTP.Response(404, "Agent not found")

--- a/backend/src/api/spec/api-spec.yaml
+++ b/backend/src/api/spec/api-spec.yaml
@@ -52,7 +52,7 @@ paths:
                 - description
                 - blueprint
       responses:
-        '200':
+        '201':
           description: Agent created successfully
           content:
             application/json:

--- a/backend/src/api/validation.jl
+++ b/backend/src/api/validation.jl
@@ -1,0 +1,60 @@
+macro validate_model(model)
+    return quote
+        local _validation_result = validate_model($(esc(model)))
+        if _validation_result !== nothing
+            @info "Validation failed for $(typeof($(esc(model))))"
+            return _validation_result
+        end
+    end
+end
+
+function validate_model(model)::Union{HTTP.Response, Nothing}
+    processed_ids = Set{UInt}()
+    stack = Vector{Any}()
+    push!(stack, model)
+
+    while !isempty(stack)
+        obj = pop!(stack)
+        obj_id = objectid(obj)
+
+        if obj_id in processed_ids
+            continue
+        end
+        push!(processed_ids, obj_id)
+
+        if obj isa OpenAPI.APIModel
+            validation_result = validate_single_model!(stack, obj)
+            if validation_result !== nothing
+                return validation_result
+            end
+        elseif obj isa AbstractVector
+            for item in obj
+                push!(stack, item)
+            end
+        end
+    end
+
+    return nothing
+end
+
+function validate_single_model!(children_stack::Vector{Any}, obj)::Union{HTTP.Response, Nothing}
+    T = typeof(obj)
+
+    if !JuliaOSServer.check_required(obj)
+        return HTTP.Response(400, "Missing required fields in $(T)")
+    end
+
+    for field in fieldnames(T)
+        val = getfield(obj, field)
+        try
+            OpenAPI.validate_property(T, field, val)
+        catch e
+            return HTTP.Response(400, "Invalid value for field $(field) in $(T): $(e.message)")
+        end
+        if val isa OpenAPI.APIModel || val isa AbstractVector
+            push!(children_stack, val)
+        end
+    end
+    return nothing
+end
+

--- a/generate-server.sh
+++ b/generate-server.sh
@@ -4,14 +4,16 @@
 
 JARNAME="openapi-generator-cli.jar"
 
+API_DIR="./backend/src/api"
+
 if [ ! -f "$JARNAME" ]; then
     echo "Missing $JARNAME. Please download it from https://openapi-generator.tech/docs/installation/#jar"
     exit 1
 fi
 
 java -jar $JARNAME generate \
-    -i ./backend/src/api/spec/api-spec.yaml \
+    -i "$API_DIR/spec/api-spec.yaml" \
     -g julia-server \
-    -o ./backend/src/api/server \
+    -o "$API_DIR/server" \
     --additional-properties=packageName=JuliaOSServer \
     --additional-properties=exportModels=true

--- a/python/src/_juliaos_client_api/api/default_api.py
+++ b/python/src/_juliaos_client_api/api/default_api.py
@@ -176,7 +176,7 @@ class DefaultApi:
         _auth_settings = []  # noqa: E501
 
         _response_types_map = {
-            '200': "AgentSummary",
+            '201': "AgentSummary",
         }
 
         return self.api_client.call_api(


### PR DESCRIPTION
Changes made:
- Fixed custom return values (needs to be done manually, not derived from spec)
- Added validation logic for endpoint inputs (needs to be added manually per endpoint, but can utilize util functions for models generated from the spec)

Additional manual validations might be needed for extra constraints not covered by the generated validators.

## Motivation

The original version of the server seems to return only two different status codes from the endpoint -- 200 on success and 500 if any exception occurs. The framework used does enable specifying a custom error code by directly returning HTTP.Response (including the desired status code and encapsulating the payload of the response) from the handler function, however, this needs to be reflected in the return type of the handler function, which needs to cover all possible return values. It is a possibility to use custom templates for the server generation, for example in order to make this return value typing more thorough and consistent, but for these purposes it is not needed, though we might make use of it later for some other adjustments.

The generated code also doesn't do full validation of the inputs (e.g. it is not checked whether a required field is present), so handler functions will need to be expanded to include additional checks to return 4XX when appropriate.