### PR TITLE
Feat/add more metadata to agents

### DIFF
--- a/a2a/src/a2a/agents/card.py
+++ b/a2a/src/a2a/agents/card.py
@@ -1,22 +1,22 @@
 from a2a.types import AgentCard, AgentSkill, AgentCapabilities
+from juliaos import Agent
 
-def make_agent_card(agent_id: str, port: int) -> AgentCard:
-    skill_map = {
-        "add2-agent": ("Add Two", "Adds +2 to input"),
-    }
+def make_agent_card(agent: Agent, port: int) -> AgentCard:
+    agent_id = agent.id
+    name = agent.name
+    description = agent.description
 
-    name, desc = skill_map.get(agent_id, ("Unknown", "Unknown"))
     return AgentCard(
-        name=f"{agent_id} agent",
+        name=name,
         version="1.0",
-        description=desc,
+        description=description,
         url=f"http://127.0.0.1:{port}/{agent_id}/a2a",
         capabilities=AgentCapabilities(streaming=False),
         skills=[
             AgentSkill(
                 id=agent_id,
                 name=name,
-                description=desc,
+                description=description,
                 tags=[]
             )
         ],

--- a/a2a/src/a2a/example/create_add2_agent.py
+++ b/a2a/src/a2a/example/create_add2_agent.py
@@ -24,6 +24,8 @@ AGENT_BLUEPRINT = juliaos.AgentBlueprint(
 )
 
 AGENT_ID = "add2-agent"
+AGENT_NAME = "Adder Agent"
+AGENT_DESCRIPTION = "Adds 2 multiple times"
 
 with juliaos.JuliaOSConnection(HOST) as conn:
     print_agents = lambda: print("Agents:", conn.list_agents())
@@ -34,7 +36,7 @@ with juliaos.JuliaOSConnection(HOST) as conn:
             print("   ", log)
 
     print_agents()
-    agent = juliaos.Agent.create(conn, AGENT_BLUEPRINT, AGENT_ID)
+    agent = juliaos.Agent.create(conn, AGENT_BLUEPRINT, AGENT_ID, AGENT_NAME, AGENT_DESCRIPTION)
     print_agents()
     agent.set_state(juliaos.AgentState.RUNNING)
     print_agents()

--- a/a2a/src/a2a/server.py
+++ b/a2a/src/a2a/server.py
@@ -10,19 +10,27 @@ from agents import register_all_agents
 from agents.registry import get_executor
 from agents.card import make_agent_card
 
-AGENT_IDS = ["add2-agent"]
+import juliaos
+
 PORT = 9100
 
 register_all_agents()
 
+conn = juliaos.JuliaOSConnection("http://127.0.0.1:8052/api/v1")
+agents = conn.list_agents()
+
 routes = []
-for agent_id in AGENT_IDS:
+for agent in agents:
+    if agent.state != juliaos.AgentState.RUNNING:
+        continue
+
+    agent_id = agent.id
     handler = DefaultRequestHandler(
         agent_executor=get_executor(agent_id),
         task_store=InMemoryTaskStore()
     )
     a2a_subapp = A2AStarletteApplication(
-        agent_card=make_agent_card(agent_id, port=PORT),
+        agent_card=make_agent_card(agent, port=PORT),
         http_handler=handler
     ).build(rpc_url=f"/a2a")
 

--- a/backend/examples/endpoint-illustration/data/create-agent.json
+++ b/backend/examples/endpoint-illustration/data/create-agent.json
@@ -1,5 +1,7 @@
 {
 	"id": "example-agent",
+	"name": "Example Agent",
+	"description": "Adds a number multiple times",
 	"blueprint": {
 		"tools": [
 			{

--- a/backend/examples/endpoint-illustration/telegram/data/create-agent.json
+++ b/backend/examples/endpoint-illustration/telegram/data/create-agent.json
@@ -1,5 +1,7 @@
 {
 	"id": "telegram-agent",
+	"name": "Telegram Moderator Agent",
+	"description": "Checks for profanity and bans users",
 	"blueprint": {
 		"tools": [
 			{

--- a/backend/plan_and_execute_test.jl
+++ b/backend/plan_and_execute_test.jl
@@ -26,7 +26,7 @@ function main()
         TriggerConfig(Agents.CommonTypes.WEBHOOK_TRIGGER, WebhookTriggerParams())
     )
     
-    plan_execute_agent = Agents.create_agent("plan_execute_agent", plan_execute_blueprint)
+    plan_execute_agent = Agents.create_agent("plan_execute_agent", "Plan and Execute Agent", "Agent with reasoning capabilities", plan_execute_blueprint)
     @info "Created reasoning agent: $plan_execute_agent"
 
     @info "Existing agents:"

--- a/backend/src/agents/CommonTypes.jl
+++ b/backend/src/agents/CommonTypes.jl
@@ -86,6 +86,8 @@ end
 
 mutable struct Agent
     id::String
+    name::String
+    description::String
     context::AgentContext
     strategy::InstantiatedStrategy
     trigger::TriggerConfig

--- a/backend/src/agents/agent_management.jl
+++ b/backend/src/agents/agent_management.jl
@@ -4,6 +4,8 @@ const AGENTS = Dict{String, Agent}()
 
 function create_agent(
     id::String,
+    name::String,
+    description::String,
     blueprint::AgentBlueprint,
 )::Agent
     # Check if the agent with the given ID already exists
@@ -30,6 +32,8 @@ function create_agent(
     # Create the agent
     agent = Agent(
         id,
+        name,
+        description,
         context,
         strategy,
         blueprint.trigger,

--- a/backend/src/agents/utils.jl
+++ b/backend/src/agents/utils.jl
@@ -1,4 +1,4 @@
-using .CommonTypes: InstantiatedTool, InstantiatedStrategy, StrategyBlueprint, ToolBlueprint, AgentState
+using .CommonTypes: InstantiatedTool, InstantiatedStrategy, StrategyBlueprint, ToolBlueprint, AgentState, TriggerType
 
 function deserialize_object(object_type::DataType, data::Dict{String, Any})
     expected_fields = fieldnames(object_type)
@@ -62,5 +62,16 @@ const NAME_TO_AGENT_STATE = Dict(v => k for (k, v) in AGENT_STATE_NAMES)
 function string_to_agent_state(name::String)::AgentState
     return get(NAME_TO_AGENT_STATE, name) do
         error("Invalid AgentState name: $name")
+    end
+end
+
+const TRIGGER_TYPE_NAMES = Dict(
+    CommonTypes.PERIODIC_TRIGGER => "PERIODIC",
+    CommonTypes.WEBHOOK_TRIGGER => "WEBHOOK",
+)
+
+function trigger_type_to_string(trigger::TriggerType)::String
+    return get(TRIGGER_TYPE_NAMES, trigger) do
+        error("Unknown TriggerType: $trigger")
     end
 end

--- a/backend/src/api/server/src/models/model_AgentSummary.jl
+++ b/backend/src/api/server/src/models/model_AgentSummary.jl
@@ -6,34 +6,52 @@
 
     AgentSummary(;
         id=nothing,
+        name=nothing,
+        description=nothing,
         state=nothing,
+        trigger_type=nothing,
     )
 
     - id::String
+    - name::String : Human-readable name of the agent
+    - description::String : Brief summary of what the agent does
     - state::String : The current state of the agent
+    - trigger_type::String : Specifies how the agent is activated
 """
 Base.@kwdef mutable struct AgentSummary <: OpenAPI.APIModel
     id::Union{Nothing, String} = nothing
+    name::Union{Nothing, String} = nothing
+    description::Union{Nothing, String} = nothing
     state::Union{Nothing, String} = nothing
+    trigger_type::Union{Nothing, String} = nothing
 
-    function AgentSummary(id, state, )
+    function AgentSummary(id, name, description, state, trigger_type, )
         OpenAPI.validate_property(AgentSummary, Symbol("id"), id)
+        OpenAPI.validate_property(AgentSummary, Symbol("name"), name)
+        OpenAPI.validate_property(AgentSummary, Symbol("description"), description)
         OpenAPI.validate_property(AgentSummary, Symbol("state"), state)
-        return new(id, state, )
+        OpenAPI.validate_property(AgentSummary, Symbol("trigger_type"), trigger_type)
+        return new(id, name, description, state, trigger_type, )
     end
 end # type AgentSummary
 
-const _property_types_AgentSummary = Dict{Symbol,String}(Symbol("id")=>"String", Symbol("state")=>"String", )
+const _property_types_AgentSummary = Dict{Symbol,String}(Symbol("id")=>"String", Symbol("name")=>"String", Symbol("description")=>"String", Symbol("state")=>"String", Symbol("trigger_type")=>"String", )
 OpenAPI.property_type(::Type{ AgentSummary }, name::Symbol) = Union{Nothing,eval(Base.Meta.parse(_property_types_AgentSummary[name]))}
 
 function check_required(o::AgentSummary)
     o.id === nothing && (return false)
+    o.name === nothing && (return false)
+    o.description === nothing && (return false)
     o.state === nothing && (return false)
+    o.trigger_type === nothing && (return false)
     true
 end
 
 function OpenAPI.validate_property(::Type{ AgentSummary }, name::Symbol, val)
     if name === Symbol("state")
         OpenAPI.validate_param(name, "AgentSummary", :enum, val, ["CREATED", "RUNNING", "PAUSED", "STOPPED"])
+    end
+    if name === Symbol("trigger_type")
+        OpenAPI.validate_param(name, "AgentSummary", :enum, val, ["PERIODIC", "WEBHOOK"])
     end
 end

--- a/backend/src/api/server/src/models/model_CreateAgentRequest.jl
+++ b/backend/src/api/server/src/models/model_CreateAgentRequest.jl
@@ -6,28 +6,38 @@
 
     CreateAgentRequest(;
         id=nothing,
+        name=nothing,
+        description=nothing,
         blueprint=nothing,
     )
 
     - id::String : Unique identifier for the agent
+    - name::String : Human-readable name of the agent
+    - description::String : Short summary of what the agent does
     - blueprint::AgentBlueprint
 """
 Base.@kwdef mutable struct CreateAgentRequest <: OpenAPI.APIModel
     id::Union{Nothing, String} = nothing
+    name::Union{Nothing, String} = nothing
+    description::Union{Nothing, String} = nothing
     blueprint = nothing # spec type: Union{ Nothing, AgentBlueprint }
 
-    function CreateAgentRequest(id, blueprint, )
+    function CreateAgentRequest(id, name, description, blueprint, )
         OpenAPI.validate_property(CreateAgentRequest, Symbol("id"), id)
+        OpenAPI.validate_property(CreateAgentRequest, Symbol("name"), name)
+        OpenAPI.validate_property(CreateAgentRequest, Symbol("description"), description)
         OpenAPI.validate_property(CreateAgentRequest, Symbol("blueprint"), blueprint)
-        return new(id, blueprint, )
+        return new(id, name, description, blueprint, )
     end
 end # type CreateAgentRequest
 
-const _property_types_CreateAgentRequest = Dict{Symbol,String}(Symbol("id")=>"String", Symbol("blueprint")=>"AgentBlueprint", )
+const _property_types_CreateAgentRequest = Dict{Symbol,String}(Symbol("id")=>"String", Symbol("name")=>"String", Symbol("description")=>"String", Symbol("blueprint")=>"AgentBlueprint", )
 OpenAPI.property_type(::Type{ CreateAgentRequest }, name::Symbol) = Union{Nothing,eval(Base.Meta.parse(_property_types_CreateAgentRequest[name]))}
 
 function check_required(o::CreateAgentRequest)
     o.id === nothing && (return false)
+    o.name === nothing && (return false)
+    o.description === nothing && (return false)
     o.blueprint === nothing && (return false)
     true
 end

--- a/backend/src/api/server/src/models/model_TriggerConfig.jl
+++ b/backend/src/api/server/src/models/model_TriggerConfig.jl
@@ -34,6 +34,6 @@ end
 
 function OpenAPI.validate_property(::Type{ TriggerConfig }, name::Symbol, val)
     if name === Symbol("type")
-        OpenAPI.validate_param(name, "TriggerConfig", :enum, val, ["webhook"])
+        OpenAPI.validate_param(name, "TriggerConfig", :enum, val, ["webhook", "periodic"])
     end
 end

--- a/backend/src/api/spec/api-spec.yaml
+++ b/backend/src/api/spec/api-spec.yaml
@@ -36,10 +36,20 @@ paths:
                 id:
                   type: string
                   description: Unique identifier for the agent
+                name:
+                  type: string
+                  description: Human-readable name of the agent
+                  example: "Email Triage Bot"
+                description:
+                  type: string
+                  description: Short summary of what the agent does
+                  example: "Automatically processes and routes incoming support emails."
                 blueprint:
                   $ref: '#/components/schemas/AgentBlueprint'
               required:
                 - id
+                - name
+                - description
                 - blueprint
       responses:
         '200':
@@ -223,15 +233,30 @@ components:
         id:
           type: string
           example: "agent123"
+        name:
+          type: string
+          example: "My First Agent"
+          description: Human-readable name of the agent
+        description:
+          type: string
+          description: Brief summary of what the agent does
+          example: "Automatically triages incoming customer-support emails and escalates when necessary."
         state:
           type: string
           enum: ["CREATED", "RUNNING", "PAUSED", "STOPPED"]
           example: "RUNNING"
           description: The current state of the agent
+        trigger_type:
+          type: string
+          enum: ["PERIODIC", "WEBHOOK"]
+          example: "PERIODIC"
+          description: Specifies how the agent is activated
       required:
         - id
         - name
-        - state  
+        - description
+        - state
+        - trigger_type
 
     AgentBlueprint:
       type: object
@@ -293,7 +318,7 @@ components:
       properties:
         type:
           type: string
-          enum: ["webhook"]
+          enum: ["webhook", "periodic"]
         params:
           type: object
           additionalProperties: true

--- a/backend/support_test.jl
+++ b/backend/support_test.jl
@@ -37,7 +37,7 @@ function main()
         TriggerConfig(Agents.CommonTypes.WEBHOOK_TRIGGER, WebhookTriggerParams())
     )
 
-    support_agent = Agents.create_agent("support_agent", support_blueprint)
+    support_agent = Agents.create_agent("support_agent", "Telegram Support Agent", "Responds to user messages", support_blueprint)
     @info "Created support agent: $support_agent"
 
     @info "Existing agents:"

--- a/backend/telegram_test.jl
+++ b/backend/telegram_test.jl
@@ -42,7 +42,7 @@ function main()
         TriggerConfig(Agents.CommonTypes.WEBHOOK_TRIGGER, WebhookTriggerParams())
     )
 
-    moderator_agent = Agents.create_agent("telegram_moderator_agent", moderator_blueprint)
+    moderator_agent = Agents.create_agent("telegram_moderator_agent", "Telegram Moderator Agent", "Checks for profanity and bans users", moderator_blueprint)
     @info "Created moderator agent: $moderator_agent"
 
     @info "Existing agents:"

--- a/backend/temp_test.jl
+++ b/backend/temp_test.jl
@@ -28,7 +28,7 @@ function main()
         )
     )
 
-    example_agent = Agents.create_agent("example_agent", example_blueprint)
+    example_agent = Agents.create_agent("example_agent", "Example Agent", "Adds 2", example_blueprint)
     @info "Created agent: $example_agent"
 
     @info "Exising agents:"

--- a/python/scripts/run_example_agent.py
+++ b/python/scripts/run_example_agent.py
@@ -1,6 +1,6 @@
 import juliaos
 
-HOST = "http://localhost:8052/api/v1"
+HOST = "http://127.0.0.1:8052/api/v1"
 
 AGENT_BLUEPRINT = juliaos.AgentBlueprint(
     tools=[
@@ -24,6 +24,8 @@ AGENT_BLUEPRINT = juliaos.AgentBlueprint(
 )
 
 AGENT_ID = "test-agent"
+AGENT_NAME = "Example Agent"
+AGENT_DESCRIPTION = "Adds the number multiple times"
 
 with juliaos.JuliaOSConnection(HOST) as conn:
     print_agents = lambda: print("Agents:", conn.list_agents())
@@ -34,7 +36,7 @@ with juliaos.JuliaOSConnection(HOST) as conn:
             print("   ", log)
 
     print_agents()
-    agent = juliaos.Agent.create(conn, AGENT_BLUEPRINT, AGENT_ID)
+    agent = juliaos.Agent.create(conn, AGENT_BLUEPRINT, AGENT_ID, AGENT_NAME, AGENT_DESCRIPTION)
     print_agents()
     agent.set_state(juliaos.AgentState.RUNNING)
     print_agents()

--- a/python/src/_juliaos_client_api/models/agent_summary.py
+++ b/python/src/_juliaos_client_api/models/agent_summary.py
@@ -26,14 +26,24 @@ class AgentSummary(BaseModel):
     AgentSummary
     """
     id: StrictStr = Field(...)
+    name: StrictStr = Field(default=..., description="Human-readable name of the agent")
+    description: StrictStr = Field(default=..., description="Brief summary of what the agent does")
     state: StrictStr = Field(default=..., description="The current state of the agent")
-    __properties = ["id", "state"]
+    trigger_type: StrictStr = Field(default=..., description="Specifies how the agent is activated")
+    __properties = ["id", "name", "description", "state", "trigger_type"]
 
     @validator('state')
     def state_validate_enum(cls, value):
         """Validates the enum"""
         if value not in ('CREATED', 'RUNNING', 'PAUSED', 'STOPPED'):
             raise ValueError("must be one of enum values ('CREATED', 'RUNNING', 'PAUSED', 'STOPPED')")
+        return value
+
+    @validator('trigger_type')
+    def trigger_type_validate_enum(cls, value):
+        """Validates the enum"""
+        if value not in ('PERIODIC', 'WEBHOOK'):
+            raise ValueError("must be one of enum values ('PERIODIC', 'WEBHOOK')")
         return value
 
     class Config:
@@ -73,7 +83,10 @@ class AgentSummary(BaseModel):
 
         _obj = AgentSummary.parse_obj({
             "id": obj.get("id"),
-            "state": obj.get("state")
+            "name": obj.get("name"),
+            "description": obj.get("description"),
+            "state": obj.get("state"),
+            "trigger_type": obj.get("trigger_type")
         })
         return _obj
 

--- a/python/src/_juliaos_client_api/models/create_agent_request.py
+++ b/python/src/_juliaos_client_api/models/create_agent_request.py
@@ -27,8 +27,10 @@ class CreateAgentRequest(BaseModel):
     CreateAgentRequest
     """
     id: StrictStr = Field(default=..., description="Unique identifier for the agent")
+    name: StrictStr = Field(default=..., description="Human-readable name of the agent")
+    description: StrictStr = Field(default=..., description="Short summary of what the agent does")
     blueprint: AgentBlueprint = Field(...)
-    __properties = ["id", "blueprint"]
+    __properties = ["id", "name", "description", "blueprint"]
 
     class Config:
         """Pydantic configuration"""
@@ -70,6 +72,8 @@ class CreateAgentRequest(BaseModel):
 
         _obj = CreateAgentRequest.parse_obj({
             "id": obj.get("id"),
+            "name": obj.get("name"),
+            "description": obj.get("description"),
             "blueprint": AgentBlueprint.from_dict(obj.get("blueprint")) if obj.get("blueprint") is not None else None
         })
         return _obj

--- a/python/src/_juliaos_client_api/models/trigger_config.py
+++ b/python/src/_juliaos_client_api/models/trigger_config.py
@@ -32,8 +32,8 @@ class TriggerConfig(BaseModel):
     @validator('type')
     def type_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in ('webhook'):
-            raise ValueError("must be one of enum values ('webhook')")
+        if value not in ('webhook', 'periodic'):
+            raise ValueError("must be one of enum values ('webhook', 'periodic')")
         return value
 
     class Config:

--- a/python/src/juliaos/agent.py
+++ b/python/src/juliaos/agent.py
@@ -6,9 +6,11 @@ from juliaos.enums import AgentState
 
 class Agent:
     @classmethod
-    def create(cls, conn: JuliaOSConnection, blueprint: AgentBlueprint, _id: str) -> Self | None:
+    def create(cls, conn: JuliaOSConnection, blueprint: AgentBlueprint, _id: str, name: str, description: str) -> Self | None:
         api_response = conn.api.create_agent(CreateAgentRequest(
             id=_id,
+            name=name,
+            description=description,
             blueprint=blueprint
         ))
         if api_response is None:


### PR DESCRIPTION
Added name, description and trigger_type to AgentSummary. Modified everything accordingly. A2A now queries agents and exposes only RUNNING agents from the JuliaOS server